### PR TITLE
Add parallel page processing for VisionExtractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ To utilize additional options:
 - `--provider <provider>`: Force specific provider: `openrouter`, `openai`, `anthropic`, or `google` (optional).
 - `--prefer-direct`: Skip OpenRouter and use direct APIs only.
 - `-q`, `--quiet`: Disables verbose output. By default, the script prints markdown to console.
-- `-r`, `--recursive`: Processes all PDF files within the target directory recursively.
-- `-p`, `--parallel`: Processes files in parallel during recursive operation.
+- `-r`, `--recursive`: Processes all PDF files within the target directory recursively. Files are processed in parallel by default.
+- `-s`, `--single`: Process files sequentially instead of in parallel when using `-r`.
+- `-p`, `--parallel [N]`: Max parallel pages to process with VisionExtractor (default: 10). Controls how many pages are processed concurrently.
+- `-d`, `--debug`: Enable debug logging for page processing order. Useful for diagnosing page ordering issues.
 - `--extractor <extractor>`: Extraction method: `vision` (default, LLM-based) or `llamaparse` (LlamaCloud API).
 - `--llamaparse-tier <tier>`: LlamaParse processing tier (only with `--extractor llamaparse`): `fast`, `cost_effective`, `agentic` (default), `agentic_plus`.
 - `--language <lang>`: Document language code for LlamaParse (default: `en`).
@@ -217,14 +219,20 @@ To utilize additional options:
 # Use specific provider
 ./pdf_to_md.py document.pdf --model claude-sonnet-4.5 --provider anthropic
 
-# Process directory recursively (verbose by default)
+# Process directory recursively (files processed in parallel by default)
 ./pdf_to_md.py ./documents -r
+
+# Process directory sequentially (one file at a time)
+./pdf_to_md.py ./documents -r -s
 
 # Process directory quietly (no console output)
 ./pdf_to_md.py ./documents -r -q
 
-# Process directory in parallel
-./pdf_to_md.py ./documents -r -p
+# Limit parallel page processing to 5 concurrent pages
+./pdf_to_md.py document.pdf -p 5
+
+# Enable debug logging to see page processing order
+./pdf_to_md.py document.pdf -d
 
 # Use LlamaParse extraction (requires LLAMA_CLOUD_API_KEY)
 ./pdf_to_md.py document.pdf --extractor llamaparse

--- a/extractors.py
+++ b/extractors.py
@@ -76,6 +76,7 @@ class VisionExtractor(BaseExtractor):
         provider: "BaseProvider",
         model_id: str,
         mode: str = "vt",
+        max_parallel_pages: int = 10,
     ):
         """
         Initialize VisionExtractor.
@@ -84,10 +85,12 @@ class VisionExtractor(BaseExtractor):
             provider: LLM provider instance (from llm_providers module).
             model_id: Model identifier for the provider.
             mode: Processing mode - 'v' for vision-only, 'vt' for vision-and-text.
+            max_parallel_pages: Maximum number of pages to process in parallel.
         """
         self.provider = provider
         self.model_id = model_id
         self.mode = mode
+        self.max_parallel_pages = max_parallel_pages
 
         # Validate mode
         if mode not in ["v", "vt"]:
@@ -106,6 +109,9 @@ class VisionExtractor(BaseExtractor):
         """
         Extract markdown from PDF using vision LLM.
 
+        Pages are processed in parallel up to max_parallel_pages concurrent
+        requests. Results are reconstructed in correct page order.
+
         Args:
             pdf_path: Path to the PDF file.
             output_dir: Directory for cached images.
@@ -114,6 +120,8 @@ class VisionExtractor(BaseExtractor):
         Returns:
             ExtractionResult with markdown content.
         """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         pdf_file_name = os.path.basename(pdf_path)
 
         # Get images
@@ -132,23 +140,50 @@ class VisionExtractor(BaseExtractor):
                 f"the number of images ({len(images)})."
             )
 
-        # Build the markdown
-        markdown_content = []
-        iterator = zip(images, prior_texts)
-        if verbose:
-            iterator = tqdm(list(iterator), desc="Processing pages")
+        def process_page(
+            page_index: int, image: "Image.Image", prior_text: Optional[str]
+        ) -> tuple[int, str]:
+            """
+            Process a single page and return (index, content).
 
-        for ix, (image, prior_text) in enumerate(iterator):
+            Args:
+                page_index: Zero-based page index.
+                image: PIL Image of the page.
+                prior_text: Optional extracted text for context.
+
+            Returns:
+                Tuple of (page_index, markdown_content_with_header).
+            """
             image_base64 = self._pdf_image_to_base64_str(image)
             markdown_text = self._process_image_with_provider(
                 image_base64,
                 prior_text,
             )
-            page_header = f"File: {pdf_file_name}; Page: {ix + 1}\n"
-            markdown_content.append(page_header + markdown_text)
+            page_header = f"File: {pdf_file_name}; Page: {page_index + 1}\n"
+            return page_index, page_header + markdown_text
 
-            if verbose and not isinstance(iterator, tqdm):
-                print(page_header + markdown_text)
+        # Process pages in parallel
+        results: dict[int, str] = {}
+
+        with ThreadPoolExecutor(max_workers=self.max_parallel_pages) as executor:
+            futures = {
+                executor.submit(process_page, ix, img, txt): ix
+                for ix, (img, txt) in enumerate(zip(images, prior_texts))
+            }
+
+            # Use tqdm for progress if verbose
+            iterator = as_completed(futures)
+            if verbose:
+                iterator = tqdm(
+                    iterator, total=len(futures), desc="Processing pages"
+                )
+
+            for future in iterator:
+                page_index, content = future.result()
+                results[page_index] = content
+
+        # Reconstruct in page order
+        markdown_content = [results[i] for i in range(len(results))]
 
         return ExtractionResult(
             markdown="\n".join(markdown_content),
@@ -157,6 +192,7 @@ class VisionExtractor(BaseExtractor):
                 "extractor": "vision",
                 "model": self.model_id,
                 "mode": self.mode,
+                "max_parallel_pages": self.max_parallel_pages,
             },
         )
 

--- a/extractors.py
+++ b/extractors.py
@@ -176,9 +176,11 @@ class VisionExtractor(BaseExtractor):
         # Process pages in parallel
         results: dict[int, str] = {}
         completion_order: list[int] = []
+        failed_pages: list[tuple[int, str]] = []  # (page_index, error_message)
+        total_pages = len(images)
 
         logger.debug(
-            f"Starting parallel extraction: {len(images)} pages, "
+            f"Starting parallel extraction: {total_pages} pages, "
             f"max_workers={self.max_parallel_pages}"
         )
 
@@ -196,23 +198,71 @@ class VisionExtractor(BaseExtractor):
                 )
 
             for future in iterator:
-                page_index, content = future.result()
-                results[page_index] = content
-                completion_order.append(page_index)
-                logger.debug(
-                    f"Collected result for page {page_index + 1} "
-                    f"(completion #{len(completion_order)})"
-                )
+                page_index = futures[future]
+                try:
+                    result_index, content = future.result()
+                    results[result_index] = content
+                    completion_order.append(result_index)
+                    logger.debug(
+                        f"Collected result for page {result_index + 1} "
+                        f"(completion #{len(completion_order)})"
+                    )
+                except Exception as e:
+                    failed_pages.append((page_index, str(e)))
+                    logger.error(
+                        f"FAILED: Page {page_index + 1} failed to process: {e}"
+                    )
+
+        # Check for failed pages
+        if failed_pages:
+            failed_nums = [p + 1 for p, _ in failed_pages]
+            logger.error(
+                f"PAGE PROCESSING ERRORS: {len(failed_pages)} of {total_pages} "
+                f"pages failed to process. Failed pages: {failed_nums}"
+            )
+            for page_idx, error_msg in failed_pages:
+                logger.error(f"  Page {page_idx + 1}: {error_msg}")
+
+        # Check for missing pages
+        expected_pages = set(range(total_pages))
+        received_pages = set(results.keys())
+        missing_pages = expected_pages - received_pages
+        if missing_pages:
+            missing_nums = sorted([p + 1 for p in missing_pages])
+            logger.error(
+                f"MISSING PAGES: Expected {total_pages} pages but only "
+                f"received {len(results)}. Missing pages: {missing_nums}"
+            )
 
         # Reconstruct in page order
         logger.debug(f"Completion order (0-indexed): {completion_order}")
-        assembly_order = list(range(len(results)))
+        assembly_order = list(range(total_pages))
         logger.debug(f"Assembly order (0-indexed): {assembly_order}")
-        markdown_content = [results[i] for i in assembly_order]
-        logger.debug(
-            f"Assembled {len(markdown_content)} pages in order: "
-            f"{[i + 1 for i in assembly_order]}"
-        )
+
+        # Build markdown, inserting placeholder for missing pages
+        markdown_content = []
+        for i in assembly_order:
+            if i in results:
+                markdown_content.append(results[i])
+            else:
+                placeholder = (
+                    f"File: {pdf_file_name}; Page: {i + 1}\n"
+                    f"[ERROR: Page {i + 1} failed to process]\n"
+                )
+                markdown_content.append(placeholder)
+
+        # Verify assembly order matches expected sequence
+        assembled_indices = [i for i in assembly_order if i in results]
+        if assembled_indices != sorted(assembled_indices):
+            logger.error(
+                f"PAGE ORDER ERROR: Pages were not assembled in sequential "
+                f"order. Assembled indices: {assembled_indices}"
+            )
+        else:
+            logger.debug(
+                f"Assembled {len(markdown_content)} pages in order: "
+                f"{[i + 1 for i in assembly_order]}"
+            )
 
         return ExtractionResult(
             markdown="\n".join(markdown_content),

--- a/extractors.py
+++ b/extractors.py
@@ -123,61 +123,92 @@ class VisionExtractor(BaseExtractor):
         Returns:
             ExtractionResult with markdown content.
         """
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-
         pdf_file_name = os.path.basename(pdf_path)
 
-        # Get images
+        # Load page images and prior text
+        images, prior_texts = self._load_page_data(pdf_path, output_dir)
+
+        # Process all pages in parallel
+        results, failed_pages = self._process_pages_parallel(
+            images, prior_texts, pdf_file_name, verbose
+        )
+
+        # Log any errors
+        self._log_processing_errors(failed_pages, len(images), results)
+
+        # Assemble final markdown in page order
+        markdown_content = self._assemble_markdown(
+            results, len(images), pdf_file_name
+        )
+
+        return ExtractionResult(
+            markdown="\n".join(markdown_content),
+            page_count=len(images),
+            metadata={
+                "extractor": "vision",
+                "model": self.model_id,
+                "mode": self.mode,
+                "max_parallel_pages": self.max_parallel_pages,
+            },
+        )
+
+    def _load_page_data(
+        self, pdf_path: str, output_dir: str
+    ) -> tuple[List[Image.Image], List[Optional[str]]]:
+        """
+        Load page images and extract prior text from PDF.
+
+        Args:
+            pdf_path: Path to the PDF file.
+            output_dir: Directory for cached images.
+
+        Returns:
+            Tuple of (images, prior_texts) lists.
+
+        Raises:
+            ValueError: If image and text counts don't match.
+        """
         images = self._pdf_to_images_with_storage(pdf_path, output_dir)
 
-        # Get prior texts
         if self.mode == "v":
-            prior_texts = [None] * len(images)
+            prior_texts: List[Optional[str]] = [None] * len(images)
         else:  # mode == 'vt'
             prior_texts = self._get_prior_text(pdf_path)
 
-        # Check that lengths match
         if len(prior_texts) != len(images):
             raise ValueError(
                 f"The number of prior texts ({len(prior_texts)}) does not match "
                 f"the number of images ({len(images)})."
             )
 
-        def process_page(
-            page_index: int, image: "Image.Image", prior_text: Optional[str]
-        ) -> tuple[int, str]:
-            """
-            Process a single page and return (index, content).
+        return images, prior_texts
 
-            Args:
-                page_index: Zero-based page index.
-                image: PIL Image of the page.
-                prior_text: Optional extracted text for context.
+    def _process_pages_parallel(
+        self,
+        images: List[Image.Image],
+        prior_texts: List[Optional[str]],
+        pdf_file_name: str,
+        verbose: bool,
+    ) -> tuple[dict[int, str], list[tuple[int, str]]]:
+        """
+        Process all pages in parallel using ThreadPoolExecutor.
 
-            Returns:
-                Tuple of (page_index, markdown_content_with_header).
-            """
-            logger.debug(
-                f"Starting page {page_index + 1}/{len(images)} "
-                f"(0-indexed: {page_index})"
-            )
-            image_base64 = self._pdf_image_to_base64_str(image)
-            markdown_text = self._process_image_with_provider(
-                image_base64,
-                prior_text,
-            )
-            logger.debug(
-                f"Completed page {page_index + 1}/{len(images)} "
-                f"(0-indexed: {page_index})"
-            )
-            page_header = f"File: {pdf_file_name}; Page: {page_index + 1}\n"
-            return page_index, page_header + markdown_text
+        Args:
+            images: List of page images.
+            prior_texts: List of prior text for each page.
+            pdf_file_name: Name of the PDF file for headers.
+            verbose: Whether to show progress bar.
 
-        # Process pages in parallel
-        results: dict[int, str] = {}
-        completion_order: list[int] = []
-        failed_pages: list[tuple[int, str]] = []  # (page_index, error_message)
+        Returns:
+            Tuple of (results dict, failed_pages list).
+            results: Maps page index to markdown content.
+            failed_pages: List of (page_index, error_message) tuples.
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         total_pages = len(images)
+        results: dict[int, str] = {}
+        failed_pages: list[tuple[int, str]] = []
 
         logger.debug(
             f"Starting parallel extraction: {total_pages} pages, "
@@ -186,11 +217,13 @@ class VisionExtractor(BaseExtractor):
 
         with ThreadPoolExecutor(max_workers=self.max_parallel_pages) as executor:
             futures = {
-                executor.submit(process_page, ix, img, txt): ix
+                executor.submit(
+                    self._process_single_page, ix, img, txt, pdf_file_name,
+                    total_pages
+                ): ix
                 for ix, (img, txt) in enumerate(zip(images, prior_texts))
             }
 
-            # Use tqdm for progress if verbose
             iterator = as_completed(futures)
             if verbose:
                 iterator = tqdm(
@@ -202,10 +235,9 @@ class VisionExtractor(BaseExtractor):
                 try:
                     result_index, content = future.result()
                     results[result_index] = content
-                    completion_order.append(result_index)
                     logger.debug(
                         f"Collected result for page {result_index + 1} "
-                        f"(completion #{len(completion_order)})"
+                        f"(completed {len(results)}/{total_pages})"
                     )
                 except Exception as e:
                     failed_pages.append((page_index, str(e)))
@@ -213,7 +245,59 @@ class VisionExtractor(BaseExtractor):
                         f"FAILED: Page {page_index + 1} failed to process: {e}"
                     )
 
-        # Check for failed pages
+        return results, failed_pages
+
+    def _process_single_page(
+        self,
+        page_index: int,
+        image: Image.Image,
+        prior_text: Optional[str],
+        pdf_file_name: str,
+        total_pages: int,
+    ) -> tuple[int, str]:
+        """
+        Process a single page and return its markdown content.
+
+        Args:
+            page_index: Zero-based page index.
+            image: PIL Image of the page.
+            prior_text: Optional extracted text for context.
+            pdf_file_name: Name of the PDF file for header.
+            total_pages: Total number of pages (for logging).
+
+        Returns:
+            Tuple of (page_index, markdown_content_with_header).
+        """
+        logger.debug(
+            f"Starting page {page_index + 1}/{total_pages} "
+            f"(0-indexed: {page_index})"
+        )
+
+        image_base64 = self._pdf_image_to_base64_str(image)
+        markdown_text = self._process_image_with_provider(image_base64, prior_text)
+
+        logger.debug(
+            f"Completed page {page_index + 1}/{total_pages} "
+            f"(0-indexed: {page_index})"
+        )
+
+        page_header = f"File: {pdf_file_name}; Page: {page_index + 1}\n"
+        return page_index, page_header + markdown_text
+
+    def _log_processing_errors(
+        self,
+        failed_pages: list[tuple[int, str]],
+        total_pages: int,
+        results: dict[int, str],
+    ) -> None:
+        """
+        Log errors for failed or missing pages.
+
+        Args:
+            failed_pages: List of (page_index, error_message) tuples.
+            total_pages: Expected total number of pages.
+            results: Dict of successfully processed pages.
+        """
         if failed_pages:
             failed_nums = [p + 1 for p, _ in failed_pages]
             logger.error(
@@ -223,10 +307,10 @@ class VisionExtractor(BaseExtractor):
             for page_idx, error_msg in failed_pages:
                 logger.error(f"  Page {page_idx + 1}: {error_msg}")
 
-        # Check for missing pages
         expected_pages = set(range(total_pages))
         received_pages = set(results.keys())
         missing_pages = expected_pages - received_pages
+
         if missing_pages:
             missing_nums = sorted([p + 1 for p in missing_pages])
             logger.error(
@@ -234,12 +318,26 @@ class VisionExtractor(BaseExtractor):
                 f"received {len(results)}. Missing pages: {missing_nums}"
             )
 
-        # Reconstruct in page order
-        logger.debug(f"Completion order (0-indexed): {completion_order}")
+    def _assemble_markdown(
+        self,
+        results: dict[int, str],
+        total_pages: int,
+        pdf_file_name: str,
+    ) -> list[str]:
+        """
+        Assemble markdown content in correct page order.
+
+        Args:
+            results: Dict mapping page index to markdown content.
+            total_pages: Total number of pages expected.
+            pdf_file_name: Name of PDF file for error placeholders.
+
+        Returns:
+            List of markdown strings in page order.
+        """
         assembly_order = list(range(total_pages))
         logger.debug(f"Assembly order (0-indexed): {assembly_order}")
 
-        # Build markdown, inserting placeholder for missing pages
         markdown_content = []
         for i in assembly_order:
             if i in results:
@@ -251,7 +349,7 @@ class VisionExtractor(BaseExtractor):
                 )
                 markdown_content.append(placeholder)
 
-        # Verify assembly order matches expected sequence
+        # Verify assembly order
         assembled_indices = [i for i in assembly_order if i in results]
         if assembled_indices != sorted(assembled_indices):
             logger.error(
@@ -264,16 +362,7 @@ class VisionExtractor(BaseExtractor):
                 f"{[i + 1 for i in assembly_order]}"
             )
 
-        return ExtractionResult(
-            markdown="\n".join(markdown_content),
-            page_count=len(images),
-            metadata={
-                "extractor": "vision",
-                "model": self.model_id,
-                "mode": self.mode,
-                "max_parallel_pages": self.max_parallel_pages,
-            },
-        )
+        return markdown_content
 
     def _pdf_to_images_with_storage(
         self, pdf_path: str, output_dir: str

--- a/extractors.py
+++ b/extractors.py
@@ -9,10 +9,13 @@ This module can be extended to support additional extraction methods.
 """
 import base64
 import io
+import logging
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import List, Optional, TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 from pdf2image import convert_from_path
 from PIL import Image
@@ -154,16 +157,30 @@ class VisionExtractor(BaseExtractor):
             Returns:
                 Tuple of (page_index, markdown_content_with_header).
             """
+            logger.debug(
+                f"Starting page {page_index + 1}/{len(images)} "
+                f"(0-indexed: {page_index})"
+            )
             image_base64 = self._pdf_image_to_base64_str(image)
             markdown_text = self._process_image_with_provider(
                 image_base64,
                 prior_text,
+            )
+            logger.debug(
+                f"Completed page {page_index + 1}/{len(images)} "
+                f"(0-indexed: {page_index})"
             )
             page_header = f"File: {pdf_file_name}; Page: {page_index + 1}\n"
             return page_index, page_header + markdown_text
 
         # Process pages in parallel
         results: dict[int, str] = {}
+        completion_order: list[int] = []
+
+        logger.debug(
+            f"Starting parallel extraction: {len(images)} pages, "
+            f"max_workers={self.max_parallel_pages}"
+        )
 
         with ThreadPoolExecutor(max_workers=self.max_parallel_pages) as executor:
             futures = {
@@ -181,9 +198,21 @@ class VisionExtractor(BaseExtractor):
             for future in iterator:
                 page_index, content = future.result()
                 results[page_index] = content
+                completion_order.append(page_index)
+                logger.debug(
+                    f"Collected result for page {page_index + 1} "
+                    f"(completion #{len(completion_order)})"
+                )
 
         # Reconstruct in page order
-        markdown_content = [results[i] for i in range(len(results))]
+        logger.debug(f"Completion order (0-indexed): {completion_order}")
+        assembly_order = list(range(len(results)))
+        logger.debug(f"Assembly order (0-indexed): {assembly_order}")
+        markdown_content = [results[i] for i in assembly_order]
+        logger.debug(
+            f"Assembled {len(markdown_content)} pages in order: "
+            f"{[i + 1 for i in assembly_order]}"
+        )
 
         return ExtractionResult(
             markdown="\n".join(markdown_content),

--- a/pdf_to_md.py
+++ b/pdf_to_md.py
@@ -55,6 +55,7 @@ def create_extractor(
     llamaparse_tier: str = "agentic",
     language: str = "en",
     verbose: bool = False,
+    max_parallel_pages: int = 10,
 ) -> "BaseExtractor":
     """
     Create appropriate extractor based on type.
@@ -67,6 +68,7 @@ def create_extractor(
         llamaparse_tier: Processing tier for LlamaParse extractor.
         language: Document language for LlamaParse extractor.
         verbose: Enable verbose logging.
+        max_parallel_pages: Max pages to process in parallel (VisionExtractor).
 
     Returns:
         Configured BaseExtractor instance.
@@ -86,6 +88,7 @@ def create_extractor(
             provider=provider,
             model_id=model_id,
             mode=mode,
+            max_parallel_pages=max_parallel_pages,
         )
 
 
@@ -201,9 +204,12 @@ def print_cli_configuration(args: argparse.Namespace, model: str) -> None:
         print(f"  Model:              {model}")
         print(f"  Provider override:  {args.provider or '(none - auto-detect)'}")
         print(f"  Prefer OpenRouter:  {not args.prefer_direct}")
+        print(f"  Parallel pages:     {args.parallel}")
     print(f"  Verbose:            {args.verbose}")
     print(f"  Recursive:          {args.recursive}")
-    print(f"  Parallel:           {args.parallel}")
+    if args.recursive:
+        file_mode = "sequential" if args.single else "parallel"
+        print(f"  File processing:    {file_mode}")
     print()
 
 
@@ -448,10 +454,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p",
         "--parallel",
+        type=int,
+        nargs="?",
+        const=10,
+        default=10,
+        help="Max parallel pages to process with VisionExtractor (default: 10).",
+    )
+    parser.add_argument(
+        "-s",
+        "--single",
         action="store_true",
         default=False,
-        help="If set, process each PDF file in parallel when using recursive "
-        "mode.",
+        help="Process files sequentially instead of in parallel when using -r.",
     )
     parser.add_argument(
         "--extractor",
@@ -523,20 +537,23 @@ if __name__ == "__main__":
             mode=args.mode,
             prefer_openrouter=prefer_openrouter,
             verbose=args.verbose,
+            max_parallel_pages=args.parallel,
         )
 
     # Process PDF(s) based on mode
     if args.recursive:
         validate_directory_path(args.target_path)
-        if args.parallel:
-            process_directory_parallel(
+        if args.single:
+            # Sequential processing when -s/--single is specified
+            process_directory_sequential(
                 args.target_path,
                 args.output_dir,
                 extractor,
                 args.verbose,
             )
         else:
-            process_directory_sequential(
+            # Default: parallel file processing
+            process_directory_parallel(
                 args.target_path,
                 args.output_dir,
                 extractor,

--- a/pdf_to_md.py
+++ b/pdf_to_md.py
@@ -500,15 +500,18 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Configure logging based on debug flag
+    # Configure logging - always show errors, debug only with -d flag
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    # Set extractors logger to show errors by default, debug with -d
+    extractors_logger = logging.getLogger("extractors")
     if args.debug:
-        # Only enable debug for our modules, suppress noisy HTTP client logs
-        logging.basicConfig(
-            level=logging.WARNING,
-            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-            datefmt="%H:%M:%S",
-        )
-        logging.getLogger("extractors").setLevel(logging.DEBUG)
+        extractors_logger.setLevel(logging.DEBUG)
+    else:
+        extractors_logger.setLevel(logging.ERROR)
     
     # Handle --list-models flag (before importing llm_providers)
     if args.list_models:

--- a/pdf_to_md.py
+++ b/pdf_to_md.py
@@ -502,11 +502,13 @@ if __name__ == "__main__":
 
     # Configure logging based on debug flag
     if args.debug:
+        # Only enable debug for our modules, suppress noisy HTTP client logs
         logging.basicConfig(
-            level=logging.DEBUG,
+            level=logging.WARNING,
             format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
             datefmt="%H:%M:%S",
         )
+        logging.getLogger("extractors").setLevel(logging.DEBUG)
     
     # Handle --list-models flag (before importing llm_providers)
     if args.list_models:

--- a/pdf_to_md.py
+++ b/pdf_to_md.py
@@ -7,6 +7,7 @@ file in the same directory with the same name as the PDF file. Supports
 multiple LLM providers via OpenRouter and direct APIs.
 """
 import argparse
+import logging
 import os
 import sys
 
@@ -206,6 +207,7 @@ def print_cli_configuration(args: argparse.Namespace, model: str) -> None:
         print(f"  Prefer OpenRouter:  {not args.prefer_direct}")
         print(f"  Parallel pages:     {args.parallel}")
     print(f"  Verbose:            {args.verbose}")
+    print(f"  Debug:              {args.debug}")
     print(f"  Recursive:          {args.recursive}")
     if args.recursive:
         file_mode = "sequential" if args.single else "parallel"
@@ -489,7 +491,22 @@ if __name__ == "__main__":
         default="en",
         help="Document language code for LlamaParse (default: 'en').",
     )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Enable debug logging for page processing order.",
+    )
     args = parser.parse_args()
+
+    # Configure logging based on debug flag
+    if args.debug:
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%H:%M:%S",
+        )
     
     # Handle --list-models flag (before importing llm_providers)
     if args.list_models:

--- a/tests/create_test_pdf.py
+++ b/tests/create_test_pdf.py
@@ -7,38 +7,52 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
 
-def create_test_pdf(output_path: str = "tests/fixtures/test_simple.pdf"):
+def create_test_pdf(
+    output_path: str = "tests/fixtures/test_simple.pdf",
+    num_pages: int = 5,
+) -> str:
     """
-    Create a simple test PDF with text and a table.
+    Create a simple test PDF with multiple pages.
+
+    Each page has distinct content including the page number for verification.
 
     Args:
         output_path: Path where the PDF should be saved.
+        num_pages: Number of pages to create (default: 5).
+
+    Returns:
+        The output path where the PDF was saved.
     """
     c = canvas.Canvas(output_path, pagesize=letter)
     width, height = letter
 
-    # Title
-    c.setFont("Helvetica-Bold", 24)
-    c.drawString(50, height - 50, "Test Document")
+    for page_num in range(1, num_pages + 1):
+        # Title with page number
+        c.setFont("Helvetica-Bold", 24)
+        c.drawString(50, height - 50, f"Test Document - Page {page_num}")
 
-    # Paragraph
-    c.setFont("Helvetica", 12)
-    c.drawString(50, height - 100, "This is a test page for PDF processing.")
+        # Unique content per page
+        c.setFont("Helvetica", 12)
+        c.drawString(50, height - 100, f"This is page {page_num} of {num_pages}.")
+        c.drawString(50, height - 130, f"Unique identifier: PAGE_{page_num}_CONTENT")
 
-    # Simple table
-    c.drawString(50, height - 150, "Item 1 | Item 2 | Item 3")
-    c.drawString(50, height - 170, "Value A | Value B | Value C")
-    c.drawString(50, height - 190, "Data 1  | Data 2  | Data 3")
+        # Simple table with page-specific data
+        c.drawString(50, height - 180, "Column A | Column B | Column C")
+        c.drawString(50, height - 200, "-" * 40)
+        for row in range(3):
+            c.drawString(
+                50,
+                height - 220 - (row * 20),
+                f"Row {row + 1}   | P{page_num}R{row + 1}  | Value {page_num}.{row + 1}"
+            )
 
-    # Second page (optional)
-    c.showPage()
-    c.setFont("Helvetica-Bold", 18)
-    c.drawString(50, height - 50, "Page 2")
-    c.setFont("Helvetica", 12)
-    c.drawString(50, height - 100, "This is the second page of the test document.")
+        # Add page break (except for last page)
+        if page_num < num_pages:
+            c.showPage()
 
     c.save()
-    print(f"Test PDF created at: {output_path}")
+    print(f"Test PDF created at: {output_path} ({num_pages} pages)")
+    return output_path
 
 
 if __name__ == "__main__":

--- a/tests/test_parallel_processing.py
+++ b/tests/test_parallel_processing.py
@@ -1,0 +1,335 @@
+"""
+Tests for parallel page processing functionality.
+
+Tests the VisionExtractor parallel processing and CLI argument changes
+without requiring actual API keys or external dependencies.
+"""
+import argparse
+import os
+import sys
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from extractors import ExtractionResult, VisionExtractor
+
+
+class MockProvider:
+    """Mock LLM provider for testing."""
+
+    def __init__(self):
+        """Initialize mock provider."""
+        self.call_count = 0
+
+    def process_vision(
+        self,
+        image_base64: str,
+        prompt: str,
+        prior_text: Optional[str] = None,
+        model: str = "",
+        max_tokens: int = 4096,
+    ) -> str:
+        """
+        Mock vision processing that returns predictable output.
+
+        Args:
+            image_base64: Base64-encoded image (ignored).
+            prompt: Prompt text (ignored).
+            prior_text: Prior text (included in output if provided).
+            model: Model name (ignored).
+            max_tokens: Max tokens (ignored).
+
+        Returns:
+            Mock markdown content.
+        """
+        self.call_count += 1
+        if prior_text:
+            return f"# Mock Page Content\n\nPrior text: {prior_text[:20]}..."
+        return "# Mock Page Content\n\nNo prior text provided."
+
+
+class TestVisionExtractorInit:
+    """Tests for VisionExtractor initialization."""
+
+    def test_default_max_parallel_pages(self):
+        """Test that default max_parallel_pages is 10."""
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+        )
+        assert extractor.max_parallel_pages == 10
+
+    def test_custom_max_parallel_pages(self):
+        """Test setting custom max_parallel_pages."""
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            max_parallel_pages=5,
+        )
+        assert extractor.max_parallel_pages == 5
+
+    def test_max_parallel_pages_of_one(self):
+        """Test setting max_parallel_pages to 1 (sequential)."""
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            max_parallel_pages=1,
+        )
+        assert extractor.max_parallel_pages == 1
+
+
+class TestParallelPageProcessing:
+    """Tests for parallel page processing logic."""
+
+    @patch.object(VisionExtractor, '_pdf_to_images_with_storage')
+    @patch.object(VisionExtractor, '_get_prior_text')
+    def test_page_order_preserved(
+        self, mock_get_prior_text, mock_pdf_to_images
+    ):
+        """Test that page order is preserved after parallel processing."""
+        # Create mock images (just need objects, content doesn't matter)
+        num_pages = 5
+        mock_images = [MagicMock() for _ in range(num_pages)]
+        mock_pdf_to_images.return_value = mock_images
+        mock_get_prior_text.return_value = [f"Text for page {i}" for i in range(num_pages)]
+
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            mode="vt",
+            max_parallel_pages=10,
+        )
+
+        # Mock the base64 conversion to return page index
+        def mock_base64(image):
+            # Find which mock image this is
+            for i, mock_img in enumerate(mock_images):
+                if image is mock_img:
+                    return f"base64_page_{i}"
+            return "unknown"
+
+        with patch.object(extractor, '_pdf_image_to_base64_str', side_effect=mock_base64):
+            result = extractor.extract("/fake/path.pdf", "/fake/output", verbose=False)
+
+        # Verify page order in output
+        lines = result.markdown.split('\n')
+        page_headers = [l for l in lines if l.startswith("File:")]
+        
+        assert len(page_headers) == num_pages
+        for i, header in enumerate(page_headers):
+            assert f"Page: {i + 1}" in header
+
+    @patch.object(VisionExtractor, '_pdf_to_images_with_storage')
+    @patch.object(VisionExtractor, '_get_prior_text')
+    def test_metadata_includes_max_parallel_pages(
+        self, mock_get_prior_text, mock_pdf_to_images
+    ):
+        """Test that result metadata includes max_parallel_pages."""
+        mock_pdf_to_images.return_value = [MagicMock()]
+        mock_get_prior_text.return_value = [None]
+
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            mode="v",
+            max_parallel_pages=7,
+        )
+
+        with patch.object(extractor, '_pdf_image_to_base64_str', return_value="base64"):
+            result = extractor.extract("/fake/path.pdf", "/fake/output", verbose=False)
+
+        assert result.metadata["max_parallel_pages"] == 7
+
+
+class TestCLIArguments:
+    """Tests for CLI argument parsing."""
+
+    def test_parallel_default_value(self):
+        """Test that -p defaults to 10."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-p", "--parallel",
+            type=int,
+            nargs="?",
+            const=10,
+            default=10,
+        )
+        
+        # No -p flag
+        args = parser.parse_args([])
+        assert args.parallel == 10
+
+    def test_parallel_with_no_value(self):
+        """Test that -p without value uses const (10)."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-p", "--parallel",
+            type=int,
+            nargs="?",
+            const=10,
+            default=10,
+        )
+        
+        # -p flag without value
+        args = parser.parse_args(["-p"])
+        assert args.parallel == 10
+
+    def test_parallel_with_custom_value(self):
+        """Test that -p 5 sets parallel to 5."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-p", "--parallel",
+            type=int,
+            nargs="?",
+            const=10,
+            default=10,
+        )
+        
+        args = parser.parse_args(["-p", "5"])
+        assert args.parallel == 5
+
+    def test_single_flag_default_false(self):
+        """Test that -s defaults to False."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-s", "--single",
+            action="store_true",
+            default=False,
+        )
+        
+        args = parser.parse_args([])
+        assert args.single is False
+
+    def test_single_flag_when_set(self):
+        """Test that -s sets single to True."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-s", "--single",
+            action="store_true",
+            default=False,
+        )
+        
+        args = parser.parse_args(["-s"])
+        assert args.single is True
+
+
+class TestIntegrationWithRealPDF:
+    """Integration tests using a real PDF file with mock provider."""
+
+    @pytest.fixture
+    def test_pdf_path(self, tmp_path):
+        """Create a test PDF and return its path."""
+        from tests.create_test_pdf import create_test_pdf
+
+        pdf_path = str(tmp_path / "test_multipage.pdf")
+        create_test_pdf(pdf_path, num_pages=5)
+        return pdf_path
+
+    def test_extracts_correct_number_of_pages(self, test_pdf_path, tmp_path):
+        """Test that extraction processes all pages from a real PDF."""
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            mode="v",
+            max_parallel_pages=5,
+        )
+
+        result = extractor.extract(
+            test_pdf_path, str(tmp_path), verbose=False
+        )
+
+        assert result.page_count == 5
+        assert provider.call_count == 5
+
+    def test_page_order_preserved_with_real_pdf(self, test_pdf_path, tmp_path):
+        """Test that page order is correct when processing a real PDF."""
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            mode="v",
+            max_parallel_pages=5,
+        )
+
+        result = extractor.extract(
+            test_pdf_path, str(tmp_path), verbose=False
+        )
+
+        # Verify page headers are in order
+        lines = result.markdown.split('\n')
+        page_headers = [l for l in lines if l.startswith("File:")]
+
+        assert len(page_headers) == 5
+        for i, header in enumerate(page_headers):
+            assert f"Page: {i + 1}" in header
+
+    def test_prior_text_extracted_from_real_pdf(self, test_pdf_path, tmp_path):
+        """Test that prior text is extracted from real PDF pages."""
+
+        class PriorTextCapturingProvider:
+            """Provider that captures prior_text for verification."""
+
+            def __init__(self):
+                self.captured_prior_texts = []
+
+            def process_vision(
+                self,
+                image_base64: str,
+                prompt: str,
+                prior_text: Optional[str] = None,
+                model: str = "",
+                max_tokens: int = 4096,
+            ) -> str:
+                self.captured_prior_texts.append(prior_text)
+                return "# Mock content"
+
+        provider = PriorTextCapturingProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            mode="vt",  # vision + text mode
+            max_parallel_pages=5,
+        )
+
+        extractor.extract(test_pdf_path, str(tmp_path), verbose=False)
+
+        # Should have captured 5 prior texts
+        assert len(provider.captured_prior_texts) == 5
+
+        # Each prior text should be non-None and contain page-specific content
+        # Note: order is not guaranteed due to parallel processing
+        all_prior_text = "\n".join(provider.captured_prior_texts)
+        for page_num in range(1, 6):
+            assert f"Page {page_num}" in all_prior_text
+
+    def test_parallel_with_max_workers_limit(self, test_pdf_path, tmp_path):
+        """Test that max_parallel_pages limits concurrent processing."""
+        provider = MockProvider()
+        extractor = VisionExtractor(
+            provider=provider,
+            model_id="test-model",
+            mode="v",
+            max_parallel_pages=2,  # Only 2 at a time
+        )
+
+        result = extractor.extract(
+            test_pdf_path, str(tmp_path), verbose=False
+        )
+
+        # Should still process all 5 pages correctly
+        assert result.page_count == 5
+        assert provider.call_count == 5
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Refactor `-p/--parallel` to control max concurrent pages in VisionExtractor (default: 10)
- Make `-r` process files in parallel by default
- Add `-s/--single` flag for sequential file processing when using `-r`
- VisionExtractor now uses ThreadPoolExecutor for parallel page processing
- Results are reconstructed in correct page order after parallel execution

## Changes

- `extractors.py`: Add `max_parallel_pages` parameter, refactor `extract()` for parallel processing
- `pdf_to_md.py`: Update CLI arguments and processing logic
- `tests/create_test_pdf.py`: Support configurable multi-page PDF creation
- `tests/test_parallel_processing.py`: New test suite with 14 tests including real PDF integration

## Test plan

- [x] Unit tests for VisionExtractor initialization
- [x] Unit tests for parallel page ordering logic
- [x] Unit tests for CLI argument parsing
- [x] Integration tests with real 5-page PDF
- [x] All 14 tests passing