### PR TITLE
Add Claude Opus 4.6 model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ To utilize additional options:
 - `openai-gpt4o` - OpenAI GPT-4o
 - `gemini-3-flash` - Google Gemini 3 Flash
 - `gemini-3-pro` - Google Gemini 3 Pro
-- `claude-sonnet-4.5` - Anthropic Claude 3.5 Sonnet
-- `claude-opus-4.5` - Anthropic Claude 3.5 Opus
-- `claude-haiku-4.5` - Anthropic Claude 3.5 Haiku
+- `claude-sonnet-4.5` - Anthropic Claude Sonnet 4.5
+- `claude-opus-4.5` - Anthropic Claude Opus 4.5
+- `claude-opus-4.6` - Anthropic Claude Opus 4.6
+- `claude-haiku-4.5` - Anthropic Claude Haiku 4.5
 
 **Examples:**
 

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -436,72 +436,45 @@ def get_available_models_for_keys() -> List[Dict]:
     models_config = load_models_config()
     available_models = []
 
+    def add_direct_model(
+        name: str, config: Dict, provider_name: str
+    ) -> None:
+        if available.get(provider_name):
+            available_models.append(
+                {
+                    "name": name,
+                    "display_name": config.get("direct_id", ""),
+                    "provider": provider_name,
+                }
+            )
+
+    def add_openrouter_model(name: str, config: Dict) -> bool:
+        openrouter_id = config.get("openrouter_id")
+        if not openrouter_id:
+            return False
+        available_models.append(
+            {
+                "name": name,
+                "display_name": openrouter_id,
+                "provider": "openrouter",
+            }
+        )
+        return True
+
     # If OpenRouter is available, use models with OpenRouter IDs first
     if available["openrouter"]:
         for model_name, model_config in models_config.items():
-            openrouter_id = model_config.get("openrouter_id")
-            if openrouter_id:
-                available_models.append(
-                    {
-                        "name": model_name,
-                        "display_name": openrouter_id,
-                        "provider": "openrouter",
-                    }
-                )
-            else:
-                provider = model_config["provider"]
-                if provider == "openai" and available["openai"]:
-                    available_models.append(
-                        {
-                            "name": model_name,
-                            "display_name": model_config.get("direct_id", ""),
-                            "provider": provider,
-                        }
-                    )
-                elif provider == "google" and available["google"]:
-                    available_models.append(
-                        {
-                            "name": model_name,
-                            "display_name": model_config.get("direct_id", ""),
-                            "provider": provider,
-                        }
-                    )
-                elif provider == "anthropic" and available["anthropic"]:
-                    available_models.append(
-                        {
-                            "name": model_name,
-                            "display_name": model_config.get("direct_id", ""),
-                            "provider": provider,
-                        }
-                    )
+            if add_openrouter_model(model_name, model_config):
+                continue
+            add_direct_model(
+                model_name, model_config, model_config["provider"]
+            )
     else:
         # Otherwise, check direct provider APIs
         for model_name, model_config in models_config.items():
-            provider = model_config["provider"]
-            if provider == "openai" and available["openai"]:
-                available_models.append(
-                    {
-                        "name": model_name,
-                        "display_name": model_config.get("direct_id", ""),
-                        "provider": provider,
-                    }
-                )
-            elif provider == "google" and available["google"]:
-                available_models.append(
-                    {
-                        "name": model_name,
-                        "display_name": model_config.get("direct_id", ""),
-                        "provider": provider,
-                    }
-                )
-            elif provider == "anthropic" and available["anthropic"]:
-                available_models.append(
-                    {
-                        "name": model_name,
-                        "display_name": model_config.get("direct_id", ""),
-                        "provider": provider,
-                    }
-                )
+            add_direct_model(
+                model_name, model_config, model_config["provider"]
+            )
 
     return available_models
 

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -9,7 +9,6 @@ All providers support vision processing with base64-encoded images.
 """
 import json
 import os
-import warnings
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Tuple
 
@@ -20,7 +19,6 @@ import google.genai as genai
 
 # Load environment variables
 load_dotenv()
-
 
 class BaseProvider(ABC):
     """Abstract base class for LLM providers."""
@@ -438,16 +436,44 @@ def get_available_models_for_keys() -> List[Dict]:
     models_config = load_models_config()
     available_models = []
 
-    # If OpenRouter is available, all models are available via OpenRouter
+    # If OpenRouter is available, use models with OpenRouter IDs first
     if available["openrouter"]:
         for model_name, model_config in models_config.items():
-            available_models.append(
-                {
-                    "name": model_name,
-                    "display_name": model_config.get("openrouter_id", ""),
-                    "provider": "openrouter",
-                }
-            )
+            openrouter_id = model_config.get("openrouter_id")
+            if openrouter_id:
+                available_models.append(
+                    {
+                        "name": model_name,
+                        "display_name": openrouter_id,
+                        "provider": "openrouter",
+                    }
+                )
+            else:
+                provider = model_config["provider"]
+                if provider == "openai" and available["openai"]:
+                    available_models.append(
+                        {
+                            "name": model_name,
+                            "display_name": model_config.get("direct_id", ""),
+                            "provider": provider,
+                        }
+                    )
+                elif provider == "google" and available["google"]:
+                    available_models.append(
+                        {
+                            "name": model_name,
+                            "display_name": model_config.get("direct_id", ""),
+                            "provider": provider,
+                        }
+                    )
+                elif provider == "anthropic" and available["anthropic"]:
+                    available_models.append(
+                        {
+                            "name": model_name,
+                            "display_name": model_config.get("direct_id", ""),
+                            "provider": provider,
+                        }
+                    )
     else:
         # Otherwise, check direct provider APIs
         for model_name, model_config in models_config.items():
@@ -548,9 +574,10 @@ def resolve_model(
 
     # Determine which provider to use
     use_openrouter = False
-    if prefer_openrouter and available["openrouter"]:
+    openrouter_id = model_config.get("openrouter_id")
+    if prefer_openrouter and available["openrouter"] and openrouter_id:
         use_openrouter = True
-        model_id = model_config["openrouter_id"]
+        model_id = openrouter_id
         provider = OpenRouterProvider()
     elif provider_name == "openai" and available["openai"]:
         model_id = model_config["direct_id"]

--- a/models.json
+++ b/models.json
@@ -36,6 +36,12 @@
     "direct_id": "claude-opus-4-5-20251101",
     "supports_vision": true
   },
+  "claude-opus-4.6": {
+    "provider": "anthropic",
+    "openrouter_id": "anthropic/claude-opus-4.6",
+    "direct_id": "claude-opus-4-6",
+    "supports_vision": true
+  },
   "claude-haiku-4.5": {
     "provider": "anthropic",
     "openrouter_id": "anthropic/claude-haiku-4.5",


### PR DESCRIPTION
## Summary
- add Claude Opus 4.6 to the model registry and documentation
- avoid OpenRouter routing when a model lacks an OpenRouter ID
- keep direct-provider resolution behavior consistent

## Test plan
- Not run (not requested)

Made with [Cursor](https://cursor.com)