### PR TITLE
Use data-files for models.json; remove pdf_to_md_data package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ Choose your installer. Dependencies are defined in `pyproject.toml`; `requiremen
 Install so `pdf_to_md` is on PATH from any directory:
 
 ```bash
-pipx install git+https://github.com/scottkwong/pdf_to_md.git
+pipx install "pdf-to-md @ git+https://github.com/scottkwong/pdf_to_md.git"
 ```
 
 Optional: add the PyMuPDF parser for faster first-pass text extraction:
 
 ```bash
-pipx install "git+https://github.com/scottkwong/pdf_to_md.git[pymupdf]"
+pipx install "pdf-to-md[pymupdf] @ git+https://github.com/scottkwong/pdf_to_md.git"
 ```
 
 To install a specific version (requires a git tag, e.g. `v0.1.0`):
 
 ```bash
-pipx install git+https://github.com/scottkwong/pdf_to_md.git@v0.1.0
+pipx install "pdf-to-md @ git+https://github.com/scottkwong/pdf_to_md.git@v0.1.0"
 ```
 
 Alternatively, from a local clone:

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -362,10 +362,8 @@ def load_models_config() -> Dict:
         FileNotFoundError: If models.json is not found.
         json.JSONDecodeError: If models.json is invalid JSON.
     """
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    models_path = os.path.join(script_dir, "models.json")
-    with open(models_path, "r") as f:
-        return json.load(f)
+    from models_config import load_models_config as _load
+    return _load()
 
 
 def validate_openrouter_key(api_key: str) -> bool:

--- a/models_config.py
+++ b/models_config.py
@@ -1,0 +1,49 @@
+"""
+Load models.json from package data or filesystem.
+
+Resolves models.json whether running from a clone (dev) or from an
+installed package (pip/pipx).
+"""
+import json
+import os
+from typing import Dict
+
+
+def _find_models_path() -> str:
+    """Return path to models.json, for dev or installed package.
+
+    Returns:
+        Absolute path to models.json.
+
+    Raises:
+        FileNotFoundError: If models.json cannot be found.
+    """
+    import sys
+
+    # Installed: models.json is in share/pdf-to-md/ (data-files)
+    installed = os.path.join(sys.prefix, "share", "pdf-to-md", "models.json")
+    if os.path.exists(installed):
+        return installed
+
+    # Dev: models.json is in repo root (next to this module)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    candidate = os.path.join(script_dir, "models.json")
+    if os.path.exists(candidate):
+        return candidate
+
+    raise FileNotFoundError("models.json not found")
+
+
+def load_models_config() -> Dict:
+    """Load and parse models.json configuration file.
+
+    Returns:
+        Dictionary of model configurations.
+
+    Raises:
+        FileNotFoundError: If models.json is not found.
+        json.JSONDecodeError: If models.json is invalid JSON.
+    """
+    models_path = _find_models_path()
+    with open(models_path, "r") as f:
+        return json.load(f)

--- a/pdf_to_md.py
+++ b/pdf_to_md.py
@@ -140,18 +140,15 @@ def pdf_to_markdown_with_extractor(
 def list_available_models() -> None:
     """
     List all available models from models.json and display them.
-    
+
     Exits the program after displaying the models.
     """
     import json
-    
-    # Load models.json directly
-    models_file = os.path.join(os.path.dirname(__file__), "models.json")
     try:
-        with open(models_file, "r") as f:
-            models_config = json.load(f)
-    except FileNotFoundError:
-        print(f"Error: models.json not found at {models_file}")
+        from models_config import load_models_config
+        models_config = load_models_config()
+    except FileNotFoundError as e:
+        print(f"Error: models.json not found: {e}")
         sys.exit(1)
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON in models.json: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pdf_to_md = "pdf_to_md:main"
 where = ["."]
 
 [tool.setuptools]
+data-files = { "share/pdf-to-md" = ["models.json"] }
 py-modules = [
     "pdf_to_md",
     "extractors",
@@ -41,4 +42,6 @@ py-modules = [
     "digital_text_parsers",
     "llamaparse_extractor",
     "benchmark_digital_text_parsers",
+    "models_config",
 ]
+


### PR DESCRIPTION
## Summary
Use setuptools data-files to install `models.json` to `share/pdf-to-md/` instead of the `pdf_to_md_data` package.

## Changes
- Add `data-files` in pyproject.toml to install `models.json` to `sys.prefix/share/pdf-to-md/`
- Add `models_config.py`: resolves `models.json` from install path (pip/pipx) or repo root (dev)
- Update `llm_providers.py` and `pdf_to_md.py` to use `load_models_config()`
- Keep flat layout; `models.json` remains at repo root

Made with [Cursor](https://cursor.com)